### PR TITLE
🤖🪵 Fix emoji placement by calculating full bounds

### DIFF
--- a/src/scale/mod.rs
+++ b/src/scale/mod.rs
@@ -889,10 +889,31 @@ impl<'a> Render<'a> {
                             outline.transform(transform);
                         }
                         let palette = proxy.color.palette(font, *palette_index);
-                        let mut base_x = 0i32;
-                        let mut base_y = 0i32;
-                        let mut base_w = 0u32;
-                        let mut base_h = 0u32;
+
+                        let mut total_bounds = zeno::Bounds::empty();
+
+                        for i in 0..outline.len() {
+                            let layer = match outline.get(i) {
+                                Some(layer) => layer,
+                                _ => {
+                                    break;
+                                }
+                            };
+                            let bounds = layer.bounds();
+                            total_bounds = total_bounds.grow(&bounds);
+                        }
+
+                        let base_x = total_bounds.min.x.floor() as i32;
+                        let base_y = total_bounds.min.y.floor() as i32;
+                        let base_w = total_bounds.width().ceil() as u32;
+                        let base_h = total_bounds.height().ceil() as u32;
+
+                        image.data.resize((base_w * base_h * 4) as usize, 0);
+                        image.placement.left = base_x;
+                        image.placement.top = (base_h as i32 + base_y);
+                        image.placement.width = total_bounds.width().ceil() as u32;
+                        image.placement.height = total_bounds.height().ceil() as u32;
+
                         let mut ok = true;
                         for i in 0..outline.len() {
                             let layer = match outline.get(i) {
@@ -902,6 +923,7 @@ impl<'a> Render<'a> {
                                     break;
                                 }
                             };
+                            
                             scratch.clear();
                             let placement = Mask::with_scratch(layer.path(), rcx)
                                 .origin(Origin::BottomLeft)
@@ -911,14 +933,6 @@ impl<'a> Render<'a> {
                                     scratch.resize(fmt.buffer_size(w, h), 0);
                                 })
                                 .render_into(&mut scratch[..], None);
-                            if i == 0 {
-                                base_x = placement.left;
-                                base_y = placement.top;
-                                base_w = placement.width;
-                                base_h = placement.height;
-                                image.data.resize((base_w * base_h * 4) as usize, 0);
-                                image.placement = placement;
-                            }
                             let color = layer
                                 .color_index()
                                 .map(|i| palette.map(|p| p.get(i)))
@@ -929,7 +943,7 @@ impl<'a> Render<'a> {
                                 placement.width,
                                 placement.height,
                                 placement.left.wrapping_sub(base_x),
-                                base_y.wrapping_sub(placement.top),
+                                (base_h as i32 + base_y).wrapping_sub(placement.top),
                                 color,
                                 &mut image.data,
                                 base_w,
@@ -947,7 +961,7 @@ impl<'a> Render<'a> {
                     if !scaler.has_bitmaps() {
                         continue;
                     }
-                    if scaler.scale_bitmap_into(glyph_id, *mode, image) {
+                        if scaler.scale_bitmap_into(glyph_id, *mode, image) {
                         return true;
                     }
                 }
@@ -955,7 +969,7 @@ impl<'a> Render<'a> {
                     if !scaler.has_color_bitmaps() {
                         continue;
                     }
-                    if scaler.scale_color_bitmap_into(glyph_id, *mode, image) {
+                        if scaler.scale_color_bitmap_into(glyph_id, *mode, image) {
                         return true;
                     }
                 }

--- a/src/scale/mod.rs
+++ b/src/scale/mod.rs
@@ -890,18 +890,7 @@ impl<'a> Render<'a> {
                         }
                         let palette = proxy.color.palette(font, *palette_index);
 
-                        let mut total_bounds = zeno::Bounds::empty();
-
-                        for i in 0..outline.len() {
-                            let layer = match outline.get(i) {
-                                Some(layer) => layer,
-                                _ => {
-                                    break;
-                                }
-                            };
-                            let bounds = layer.bounds();
-                            total_bounds = total_bounds.grow(&bounds);
-                        }
+                        let total_bounds = outline.bounds();
 
                         let base_x = total_bounds.min.x.floor() as i32;
                         let base_y = total_bounds.min.y.floor() as i32;
@@ -910,7 +899,7 @@ impl<'a> Render<'a> {
 
                         image.data.resize((base_w * base_h * 4) as usize, 0);
                         image.placement.left = base_x;
-                        image.placement.top = (base_h as i32 + base_y);
+                        image.placement.top = base_h as i32 + base_y;
                         image.placement.width = total_bounds.width().ceil() as u32;
                         image.placement.height = total_bounds.height().ceil() as u32;
 
@@ -961,7 +950,7 @@ impl<'a> Render<'a> {
                     if !scaler.has_bitmaps() {
                         continue;
                     }
-                        if scaler.scale_bitmap_into(glyph_id, *mode, image) {
+                    if scaler.scale_bitmap_into(glyph_id, *mode, image) {
                         return true;
                     }
                 }
@@ -969,7 +958,7 @@ impl<'a> Render<'a> {
                     if !scaler.has_color_bitmaps() {
                         continue;
                     }
-                        if scaler.scale_color_bitmap_into(glyph_id, *mode, image) {
+                    if scaler.scale_color_bitmap_into(glyph_id, *mode, image) {
                         return true;
                     }
                 }


### PR DESCRIPTION
Addresses incorrect emoji rendering as reported in #26

Previously the `placement` of the very first colored outline was used to calculate image dimensions, however this is incorrect. One should use the full bounds of all outlines for calculating this size.

Notice that this also needs a tiny PR on zeno https://github.com/dfrg/zeno/pull/4

Attached are correctly rendered 🤖 and 🪵 emoji's as per the issue file.

![stuff](https://user-images.githubusercontent.com/49594/202137358-ac6c2e41-802b-4feb-a560-df960a0b9107.png)
![stuff](https://user-images.githubusercontent.com/49594/202137465-26a4d706-9b9f-4195-b89e-94aaa8d1fd4d.png)
