### PR TITLE
➡️ Need to take offset into account when calculating draw area

### DIFF
--- a/src/scale/mod.rs
+++ b/src/scale/mod.rs
@@ -892,8 +892,9 @@ impl<'a> Render<'a> {
 
                         let total_bounds = outline.bounds();
 
-                        let base_x = total_bounds.min.x.floor() as i32;
-                        let base_y = total_bounds.min.y.floor() as i32;
+                        // need to take offset into account when placing glyph
+                        let base_x = (total_bounds.min.x + self.offset.x).floor() as i32;
+                        let base_y = (total_bounds.min.y + self.offset.y).ceil() as i32;
                         let base_w = total_bounds.width().ceil() as u32;
                         let base_h = total_bounds.height().ceil() as u32;
 


### PR DESCRIPTION
There was a small artifact noticeable when offset wasn't taken into account when calculating the bounds of the rectangle, leading to 1px clipping artifacts.

This would break in cosmic-text where the offset would be used to offset the glyph with a tiny fractional amount, causing incorrect rounding in this routine as a result.

https://github.com/pop-os/cosmic-text/blob/2342bf0eaebe6d41661b1fb49ed30d4021a9807d/src/swash.rs#L33-L35

Current main branch;

![image](https://user-images.githubusercontent.com/49594/203748773-866d9d86-4e78-47fe-9de3-a06c25db2a98.png)

With this fix applied;

![image](https://user-images.githubusercontent.com/49594/203748995-ff8543f5-faa8-4c87-b097-f06751926f08.png)


Notice some instances of the 💩 , 🐭and more subtly the top of the 🤖 emoji.
