### PR TITLE
Make scale::cff::Subfont public

### DIFF
--- a/src/scale/cff/outlines.rs
+++ b/src/scale/cff/outlines.rs
@@ -289,7 +289,7 @@ enum Version<'a> {
 ///
 /// For variable fonts, this is dependent on a location in variation space.
 #[derive(Clone)]
-pub(crate) struct Subfont {
+pub struct Subfont {
     is_cff2: bool,
     scale: Fixed,
     subrs_offset: Option<usize>,


### PR DESCRIPTION
To fully verity #44, I checked with `cargo msrv`. Before this change, it builds with 1.74. After, it builds with 1.65.