### PR TITLE
Only build `BitmapData` and `Metrics` with "scale" feature.

### DIFF
--- a/src/strike.rs
+++ b/src/strike.rs
@@ -774,6 +774,7 @@ fn sbix_range(table: &[u8], strike_base: usize, glyph_id: u16, recurse: i32) -> 
     }
 }
 
+#[cfg(feature = "scale")]
 #[derive(Copy, Clone)]
 struct BitmapData<'a> {
     pub data: &'a [u8],
@@ -806,6 +807,7 @@ impl<'a> BitmapData<'a> {
     }
 }
 
+#[cfg(feature = "scale")]
 #[derive(Copy, Clone, Default)]
 struct Metrics {
     pub x: i8,


### PR DESCRIPTION
These are not public, so this shouldn't be a breaking change. When building without default features (and therefore without "scale"), these structs are unused and generate warnings.