### PR TITLE
Partial no-std support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,9 @@ readme = "README.md"
 [features]
 default = ["scale", "render"]
 
-scale = ["dep:yazi", "dep:zeno"]
+std = ["skrifa/std"]
+libm = ["skrifa/libm"]
+scale = ["std", "dep:yazi", "dep:zeno"]
 render = ["scale", "zeno/eval"]
 
 [lints]
@@ -24,4 +26,4 @@ clippy.semicolon_if_nothing_returned = "warn"
 [dependencies]
 yazi = { version = "0.1.6", optional = true }
 zeno = { version = "0.2.2", optional = true, default-features = false }
-skrifa = { version = "0.22.3" }
+skrifa = { version = "0.22.3", default-features = false }

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -1,5 +1,7 @@
 use super::FontRef;
 
+use alloc::vec::Vec;
+
 /// Uniquely generated value for identifying and caching fonts.
 #[derive(Copy, Clone, PartialOrd, Ord, PartialEq, Eq, Hash, Debug)]
 pub struct CacheKey(pub(crate) u64);

--- a/src/internal/mod.rs
+++ b/src/internal/mod.rs
@@ -79,6 +79,7 @@ pub trait RawFont<'a>: Sized {
     /// Returns the offset to the table directory.
     fn offset(&self) -> u32;
 
+    #[cfg(feature = "std")]
     fn dump_tables(&self) -> Option<()> {
         let base = self.offset() as usize;
         let b = Bytes::new(self.data());

--- a/src/internal/vorg.rs
+++ b/src/internal/vorg.rs
@@ -16,7 +16,7 @@ pub fn origin(data: &[u8], vorg: u32, glyph_id: u16) -> Option<i16> {
     let mut l = 0;
     let mut h = count;
     while l < h {
-        use std::cmp::Ordering::*;
+        use core::cmp::Ordering::*;
         let i = (l + h) / 2;
         let rec = base + 8 + i * 4;
         let g = b.read::<u16>(rec)?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,11 +22,14 @@ Documentation for [shaping](shape) and [scaling](scale) is provided in
 the respective modules.
 */
 
+#![cfg_attr(not(feature = "std"), no_std)]
 #![allow(clippy::float_cmp)]
 #![allow(clippy::many_single_char_names)]
 #![allow(clippy::needless_lifetimes)]
 #![allow(clippy::redundant_static_lifetimes)]
 #![allow(clippy::too_many_arguments)]
+
+extern crate alloc;
 
 #[cfg(feature = "scale")]
 pub use zeno;

--- a/src/shape/at.rs
+++ b/src/shape/at.rs
@@ -1,6 +1,7 @@
 use super::internal::{at::*, *};
 use super::{buffer::*, feature::*, Direction};
 use crate::text::Script;
+use alloc::vec::Vec;
 use core::ops::Range;
 
 pub type FeatureBit = u16;

--- a/src/shape/buffer.rs
+++ b/src/shape/buffer.rs
@@ -4,6 +4,7 @@ use crate::text::{
     cluster::{Char, CharCluster, ClusterInfo, ShapeClass, SourceRange, MAX_CLUSTER_SIZE},
     JoiningType,
 };
+use alloc::vec::Vec;
 use core::ops::Range;
 
 // Glyph flags.

--- a/src/shape/cache.rs
+++ b/src/shape/cache.rs
@@ -2,6 +2,7 @@ use super::at::FeatureStore;
 use super::engine::EngineMetadata;
 use super::internal::var::Fvar;
 use crate::{charmap::CharmapProxy, metrics::MetricsProxy, FontRef};
+use alloc::vec::Vec;
 
 pub type Epoch = u64;
 

--- a/src/shape/engine.rs
+++ b/src/shape/engine.rs
@@ -5,6 +5,7 @@ use super::internal::{self, at::Gdef, raw_tag, Bytes, RawFont, RawTag};
 use crate::font::FontRef;
 use crate::text::{Language, Script};
 
+use alloc::vec::Vec;
 use core::ops::Range;
 
 /// Shaping engine that handles the various methods available in

--- a/src/shape/mod.rs
+++ b/src/shape/mod.rs
@@ -264,6 +264,7 @@ use crate::text::{
     cluster::{CharCluster, Parser, ShapeClass, Token},
     Language, Script,
 };
+use alloc::vec::Vec;
 use at::{FeatureMask, FeatureStore, FeatureStoreBuilder};
 use buffer::*;
 use cache::{FeatureCache, FontEntry};

--- a/src/string.rs
+++ b/src/string.rs
@@ -2,7 +2,7 @@
 Localized names and other metadata.
 */
 
-use std::fmt::Write;
+use core::fmt::Write;
 
 use super::internal::*;
 use super::FontRef;


### PR DESCRIPTION
I specifically focused on no-std support with the scale and render features disabled, because I didn't want to recurse into swash's optional dependencies, and this is the subset used by parley.

This probably needs to be a semver-breaking change (so bump to 0.2.0), because now, if you specify default-features=false, you have to specify either the std or libm feature.