### PR TITLE
Use `AtomicUsize` rather than `AtomicU64` in CacheKey.

### DIFF
--- a/src/cache.rs
+++ b/src/cache.rs
@@ -7,9 +7,9 @@ pub struct CacheKey(pub(crate) u64);
 impl CacheKey {
     /// Generates a new cache key.
     pub fn new() -> Self {
-        use core::sync::atomic::{AtomicU64, Ordering};
-        static KEY: AtomicU64 = AtomicU64::new(1);
-        Self(KEY.fetch_add(1, Ordering::Relaxed))
+        use core::sync::atomic::{AtomicUsize, Ordering};
+        static KEY: AtomicUsize = AtomicUsize::new(1);
+        Self(KEY.fetch_add(1, Ordering::Relaxed).try_into().unwrap())
     }
 
     /// Returns the underlying value of the key.


### PR DESCRIPTION
`AtomicU64` is unavailable on most 32-bit targets, but `AtomicUsize` is available most targets.

It is exceedingly unlikely that there will be more `CacheKey`s than bytes in the process address space.