### PR TITLE
Improve `std` feature propagation.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,8 +20,8 @@ targets = []
 [features]
 default = ["std", "scale", "render"]
 
-libm = ["dep:core_maths", "skrifa/libm", "zeno/libm"]
-std = ["skrifa/std", "zeno/std"]
+libm = ["dep:core_maths", "skrifa/libm", "zeno?/libm"]
+std = ["skrifa/std", "zeno?/std", "yazi?/std"]
 
 scale = ["dep:yazi", "dep:zeno"]
 render = ["scale", "zeno/eval"]


### PR DESCRIPTION
* `std` and `libm` don't necessarily require `zeno`, so only enable the matching feature when `zeno` is already depended on.
* Enable `std` also for `yazi` when appropriate.