### PR TITLE
Update `skrifa` to v0.25.0.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,4 +34,4 @@ clippy.semicolon_if_nothing_returned = "warn"
 core_maths = { version = "0.1.0", optional = true }
 yazi = { version = "0.2.0", optional = true, default-features = false }
 zeno = { version = "0.3.1", optional = true, default-features = false }
-skrifa = { version = "0.24.1", default-features = false }
+skrifa = { version = "0.25.0", default-features = false }


### PR DESCRIPTION
The breaking change was [a typo fix](https://github.com/googlefonts/fontations/commit/45d9e5349b638919331e965dab8db1ee3b184db0) which doesn't affect Swash.