### PR TITLE
Use `skrifa::NormalizedCoord` to represent normalized coordinates

### DIFF
--- a/src/internal/at.rs
+++ b/src/internal/at.rs
@@ -1,5 +1,7 @@
 //! OpenType advanced typography tables.
 
+use crate::NormalizedCoord;
+
 use super::{raw_tag, Bytes, RawTag};
 
 pub const GDEF: RawTag = raw_tag(b"GDEF");
@@ -116,7 +118,7 @@ impl<'a> Gdef<'a> {
         self.var_store != 0
     }
 
-    pub fn delta(&self, outer: u16, inner: u16, coords: &[i16]) -> f32 {
+    pub fn delta(&self, outer: u16, inner: u16, coords: &[NormalizedCoord]) -> f32 {
         if self.var_store != 0 {
             super::var::item_delta(self.data.data(), self.var_store, outer, inner, coords)
                 .map(|d| d.to_f32())
@@ -223,7 +225,7 @@ impl SubtableData {
 pub struct FeatureSubsts(u32);
 
 impl FeatureSubsts {
-    pub fn new(b: &Bytes, offset: u32, coords: &[i16]) -> Option<Self> {
+    pub fn new(b: &Bytes, offset: u32, coords: &[NormalizedCoord]) -> Option<Self> {
         if offset == 0 || coords.is_empty() {
             return None;
         }
@@ -245,11 +247,11 @@ impl FeatureSubsts {
                     break;
                 }
                 let coord = coords[axis];
-                let min = b.read::<i16>(cond_table + 4)?;
+                let min = NormalizedCoord::from_bits(b.read::<i16>(cond_table + 4)?);
                 if coord < min {
                     break;
                 }
-                let max = b.read::<i16>(cond_table + 6)?;
+                let max = NormalizedCoord::from_bits(b.read::<i16>(cond_table + 6)?);
                 if coord > max {
                     break;
                 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -95,7 +95,7 @@ use proxy::BitmapStrikesProxy;
 pub type GlyphId = u16;
 
 /// Normalized variation coordinate in 2.14 fixed point format.
-pub type NormalizedCoord = i16;
+pub type NormalizedCoord = skrifa::instance::NormalizedCoord;
 
 impl<'a> FontRef<'a> {
     /// Returns the primary attributes for the font.

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -281,7 +281,7 @@ pub struct Metrics {
 impl Metrics {
     /// Creates a new set of metrics from the specified font and
     /// normalized variation coordinates.
-    pub(crate) fn from_font(font: &FontRef, coords: &[i16]) -> Self {
+    pub(crate) fn from_font(font: &FontRef, coords: &[NormalizedCoord]) -> Self {
         let meta = MetricsProxy::from_font(font);
         meta.materialize_metrics(font, coords)
     }
@@ -320,7 +320,7 @@ impl Metrics {
 #[derive(Copy, Clone)]
 pub struct GlyphMetrics<'a> {
     data: &'a [u8],
-    coords: &'a [i16],
+    coords: &'a [NormalizedCoord],
     units_per_em: u16,
     glyph_count: u16,
     hmtx: u32,

--- a/src/scale/mod.rs
+++ b/src/scale/mod.rs
@@ -225,9 +225,8 @@ use hinting_cache::HintingCache;
 use image::*;
 use outline::*;
 use skrifa::{
-    instance::{NormalizedCoord as SkrifaNormalizedCoord, Size as SkrifaSize},
-    outline::OutlineGlyphCollection,
-    GlyphId as SkrifaGlyphId, MetadataProvider,
+    instance::Size as SkrifaSize, outline::OutlineGlyphCollection, GlyphId as SkrifaGlyphId,
+    MetadataProvider,
 };
 
 use super::internal;
@@ -288,7 +287,7 @@ pub struct ScaleContext {
     fonts: FontCache<ScalerProxy>,
     state: State,
     hinting_cache: HintingCache,
-    coords: Vec<SkrifaNormalizedCoord>,
+    coords: Vec<NormalizedCoord>,
 }
 
 struct State {
@@ -344,7 +343,7 @@ pub struct ScalerBuilder<'a> {
     outlines: Option<OutlineGlyphCollection<'a>>,
     proxy: &'a ScalerProxy,
     id: [u64; 2],
-    coords: &'a mut Vec<SkrifaNormalizedCoord>,
+    coords: &'a mut Vec<NormalizedCoord>,
     size: f32,
     hint: bool,
 }
@@ -403,7 +402,7 @@ impl<'a> ScalerBuilder<'a> {
                     if var.tag() == setting.tag {
                         let value = var.normalize(setting.value);
                         if let Some(c) = self.coords.get_mut(var.index()) {
-                            *c = SkrifaNormalizedCoord::from_bits(value);
+                            *c = value;
                         }
                     }
                 }
@@ -417,13 +416,13 @@ impl<'a> ScalerBuilder<'a> {
     pub fn normalized_coords<I>(self, coords: I) -> Self
     where
         I: IntoIterator,
-        I::Item: Borrow<NormalizedCoord>,
+        I::Item: Borrow<i16>,
     {
         self.coords.clear();
         self.coords.extend(
             coords
                 .into_iter()
-                .map(|c| SkrifaNormalizedCoord::from_bits(*c.borrow())),
+                .map(|c| NormalizedCoord::from_bits(*c.borrow())),
         );
         self
     }
@@ -470,7 +469,7 @@ pub struct Scaler<'a> {
     outlines: Option<OutlineGlyphCollection<'a>>,
     hinting_instance: Option<&'a skrifa::outline::HintingInstance>,
     proxy: &'a ScalerProxy,
-    coords: &'a [SkrifaNormalizedCoord],
+    coords: &'a [NormalizedCoord],
     size: f32,
     skrifa_size: SkrifaSize,
 }

--- a/src/shape/at.rs
+++ b/src/shape/at.rs
@@ -1,6 +1,7 @@
 use super::internal::{at::*, *};
 use super::{buffer::*, feature::*, Direction};
 use crate::text::Script;
+use crate::NormalizedCoord;
 
 use alloc::vec::Vec;
 use core::ops::Range;
@@ -287,7 +288,7 @@ impl FeatureStoreBuilder {
         &mut self,
         cache: &mut FeatureStore,
         data: &[u8],
-        coords: &[i16],
+        coords: &[NormalizedCoord],
         gdef: &Gdef,
         gsub: &StageOffsets,
         gpos: &StageOffsets,
@@ -309,7 +310,7 @@ impl FeatureStoreBuilder {
         &mut self,
         cache: &mut FeatureStore,
         b: &Bytes,
-        coords: &[i16],
+        coords: &[NormalizedCoord],
         gdef: &Gdef,
         offsets: &StageOffsets,
         stage: u8,
@@ -532,7 +533,7 @@ pub fn apply(
     stage: u8,
     data: &Bytes,
     gsubgpos: u32,
-    coords: &[i16],
+    coords: &[NormalizedCoord],
     gdef: &Gdef,
     storage: &mut Storage,
     cache: &FeatureStore,
@@ -590,7 +591,7 @@ struct ApplyContext<'a, 'b, 'c> {
     data: &'a Bytes<'a>,
     gsubgpos: u32,
     defs: &'a Gdef<'a>,
-    coords: &'a [i16],
+    coords: &'a [NormalizedCoord],
     enable_var: bool,
     cache: &'a FeatureStore,
     storage: &'b mut Storage,
@@ -608,7 +609,7 @@ impl<'a, 'b, 'c> ApplyContext<'a, 'b, 'c> {
         data: &'a Bytes<'a>,
         gsubgpos: u32,
         defs: &'a Gdef<'a>,
-        coords: &'a [i16],
+        coords: &'a [NormalizedCoord],
         cache: &'a FeatureStore,
         storage: &'b mut Storage,
         buffer: &'c mut Buffer,

--- a/src/shape/cache.rs
+++ b/src/shape/cache.rs
@@ -1,7 +1,7 @@
 use super::at::FeatureStore;
 use super::engine::EngineMetadata;
 use super::internal::var::Fvar;
-use crate::{charmap::CharmapProxy, metrics::MetricsProxy, FontRef};
+use crate::{charmap::CharmapProxy, metrics::MetricsProxy, FontRef, NormalizedCoord};
 
 use alloc::vec::Vec;
 
@@ -30,7 +30,7 @@ impl FontEntry {
 pub struct FeatureEntry {
     pub epoch: Epoch,
     pub id: [u64; 2],
-    pub coords: Vec<i16>,
+    pub coords: Vec<NormalizedCoord>,
     pub tags: [u32; 4],
     pub store: FeatureStore,
 }
@@ -58,7 +58,7 @@ impl FeatureCache {
     pub fn entry<'a>(
         &'a mut self,
         id: [u64; 2],
-        coords: &[i16],
+        coords: &[NormalizedCoord],
         has_feature_vars: bool,
         tags: &[u32; 4],
     ) -> FeatureCacheEntry<'a> {
@@ -80,7 +80,7 @@ impl FeatureCache {
     fn find_entry(
         &mut self,
         id: [u64; 2],
-        coords: &[i16],
+        coords: &[NormalizedCoord],
         has_feature_vars: bool,
         tags: &[u32; 4],
     ) -> (bool, usize) {

--- a/src/shape/engine.rs
+++ b/src/shape/engine.rs
@@ -4,6 +4,7 @@ use super::buffer::*;
 use super::internal::{self, at::Gdef, raw_tag, Bytes, RawFont, RawTag};
 use crate::font::FontRef;
 use crate::text::{Language, Script};
+use crate::NormalizedCoord;
 
 use alloc::vec::Vec;
 use core::ops::Range;
@@ -21,7 +22,7 @@ pub struct Engine<'a> {
     pub ankr: u32,
     pub kern: u32,
     pub storage: at::Storage,
-    pub coords: &'a [i16],
+    pub coords: &'a [NormalizedCoord],
     pub script: Script,
     pub lang: Option<Language>,
     pub tags: [RawTag; 4],
@@ -37,7 +38,7 @@ impl<'a> Engine<'a> {
     pub fn new(
         metadata: &EngineMetadata,
         font_data: &'a [u8],
-        coords: &'a [i16],
+        coords: &'a [NormalizedCoord],
         script: Script,
         lang: Option<Language>,
     ) -> Self {

--- a/src/shape/mod.rs
+++ b/src/shape/mod.rs
@@ -286,7 +286,7 @@ pub enum Direction {
 pub struct ShapeContext {
     font_cache: FontCache<FontEntry>,
     feature_cache: FeatureCache,
-    coords: Vec<i16>,
+    coords: Vec<NormalizedCoord>,
     state: State,
 }
 
@@ -370,7 +370,7 @@ pub struct ShaperBuilder<'a> {
     font: FontRef<'a>,
     font_id: [u64; 2],
     font_entry: &'a FontEntry,
-    coords: &'a mut Vec<i16>,
+    coords: &'a mut Vec<NormalizedCoord>,
     charmap: Charmap<'a>,
     dotted_circle: Option<u16>,
     retain_ignorables: bool,
@@ -466,7 +466,7 @@ impl<'a> ShaperBuilder<'a> {
     {
         if self.font_entry.coord_count != 0 {
             let vars = self.font.variations();
-            self.coords.resize(vars.len(), 0);
+            self.coords.resize(vars.len(), NormalizedCoord::ZERO);
             for setting in settings {
                 let setting = setting.into();
                 for var in vars {

--- a/src/variation.rs
+++ b/src/variation.rs
@@ -99,7 +99,7 @@ impl<'a> Variations<'a> {
     {
         let mut copy = *self;
         copy.pos = 0;
-        let mut coords = [0i16; 32];
+        let mut coords = [NormalizedCoord::ZERO; 32];
         let len = self.len.min(32);
         for setting in settings {
             let val = setting.into();


### PR DESCRIPTION
The motivation for this PR is to avoid [this conversion boilerplate](https://github.com/linebender/parley/blob/main/examples/vello_editor/src/text.rs#L340) (and otherwise unnecessary `Vec` allocation) when integrating `parley` (which uses swash's `NormalizedCoord`) with `vello` (which uses skrifa's `NormalizedCoord`).

Once `parley` is updated with this change it should be possible to pass `run.normalized_coords` directly to `draw_glyphs().normalized_coords`.

This PR assumes that the bit representation of normalized coords is the same in Swash and Skrifa, and that Skrifa just has a newtype around the raw bits.