### PR TITLE
Allow setting retain_ignorables in SimpleShapeOptions

### DIFF
--- a/src/shape/partition.rs
+++ b/src/shape/partition.rs
@@ -73,6 +73,12 @@ pub trait ShapeOptions {
     fn insert_dotted_circles(&self) -> bool {
         false
     }
+
+    /// Returns true if characters defined as default ignorable should be
+    /// retained by the shaper.
+    fn retain_ignorables(&self) -> bool {
+        false
+    }
 }
 
 /// Simple implementation of the shape options trait.
@@ -92,6 +98,9 @@ pub struct SimpleShapeOptions<'a> {
     pub variations: &'a [Setting<f32>],
     /// True if the shaper should insert dotted circles for broken clusters.
     pub insert_dotted_circles: bool,
+    /// True if characters defined as default ignorable should be retained by
+    /// the shaper.
+    pub retain_ignorables: bool,
 }
 
 impl Default for SimpleShapeOptions<'_> {
@@ -104,6 +113,7 @@ impl Default for SimpleShapeOptions<'_> {
             features: &[],
             variations: &[],
             insert_dotted_circles: false,
+            retain_ignorables: false,
         }
     }
 }
@@ -233,6 +243,7 @@ where
         )
         .variations(options.variations())
         .insert_dotted_circles(options.insert_dotted_circles())
+        .retain_ignorables(options.retain_ignorables())
         .build();
     loop {
         shaper.add_cluster(cluster);


### PR DESCRIPTION
This is necessary for Parley to display tab characters. Since swash incorrectly thinks the tab character is ignorable (https://github.com/linebender/parley/issues/302) and there's no way to regenerate the Unicode tables (https://github.com/dfrg/swash/issues/37), this at least lets us work around the issue.