### PR TITLE
Use both `offset` and `render_offset` in `scale`

### DIFF
--- a/src/scale/mod.rs
+++ b/src/scale/mod.rs
@@ -848,6 +848,7 @@ impl<'a> Render<'a> {
                             .format(self.format)
                             .origin(Origin::BottomLeft)
                             .style(self.style)
+                            .offset(self.offset)
                             .render_offset(self.offset)
                             .inspect(|fmt, w, h| {
                                 image.data.resize(fmt.buffer_size(w, h), 0);
@@ -913,6 +914,7 @@ impl<'a> Render<'a> {
                             let placement = Mask::with_scratch(layer.path(), rcx)
                                 .origin(Origin::BottomLeft)
                                 .style(self.style)
+                                .offset(self.offset)
                                 .render_offset(self.offset)
                                 .inspect(|fmt, w, h| {
                                     scratch.resize(fmt.buffer_size(w, h), 0);


### PR DESCRIPTION
This is the Swash half of https://github.com/dfrg/zeno/pull/15, and will require that to land first (and a new version of zeno to be released). ~~As mentioned there, you could alternatively change the code here to pass in both `offset` and `render_offset` if you want to avoid a breaking change in zeno.~~