### PR TITLE
Add word-break setting to boundary analysis

### DIFF
--- a/src/text/mod.rs
+++ b/src/text/mod.rs
@@ -14,6 +14,6 @@ mod unicode_data;
 
 pub mod cluster;
 
-pub use analyze::{analyze, Analyze};
+pub use analyze::{analyze, Analyze, WordBreakStrength};
 pub use lang::{Cjk, Language};
 pub use unicode::*;


### PR DESCRIPTION
This is necessary for implementing https://github.com/linebender/parley/issues/303.

In the long term, Parley should move to some other Unicode analysis crate, but this should do for now.