### PR TITLE
Update `skrifa` to 0.30.0.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ clippy.doc_markdown = "warn"
 clippy.semicolon_if_nothing_returned = "warn"
 
 [dependencies]
-core_maths = { version = "0.1.0", optional = true }
+core_maths = { version = "0.1.1", optional = true }
 yazi = { version = "0.2.1", optional = true, default-features = false }
 zeno = { version = "0.3.2", optional = true, default-features = false }
-skrifa = { version = "0.26.2", default-features = false }
+skrifa = { version = "0.30.0", default-features = false }


### PR DESCRIPTION
All the breaking changes in skrifa seem to be related to APIs that Swash doesn't use.

I also included a patch bump to `core_maths`, just so all the deps are up-to-date.