### PR TITLE
Make `skrifa::OutlinePen` impl private

### DIFF
--- a/src/internal/var.rs
+++ b/src/internal/var.rs
@@ -1,7 +1,5 @@
 //! Font and metric variation tables.
 
-use skrifa::raw::{FontData, FontRead};
-
 use super::{fixed::Fixed, raw_tag, Array, Bytes, RawFont, RawTag, U24};
 
 pub const FVAR: RawTag = raw_tag(b"fvar");
@@ -235,21 +233,18 @@ pub fn sb_delta(data: &[u8], xvar: u32, glyph_id: u16, coords: &[i16]) -> f32 {
 /// Applies adjustments to a coordinate according to the optional axis
 /// variation table.
 pub fn adjust_axis(data: &[u8], avar: u32, axis: u16, coord: Fixed) -> Option<Fixed> {
+    use skrifa::raw::{tables::avar::Avar, types::Fixed, FontData, FontRead};
+
     if avar == 0 {
         return None;
     }
-    let avar =
-        skrifa::raw::tables::avar::Avar::read(FontData::new(data.get(avar as usize..)?)).ok()?;
+    let avar = Avar::read(FontData::new(data.get(avar as usize..)?)).ok()?;
     let mapping = avar
         .axis_segment_maps()
         .get(axis as usize)
         .transpose()
         .ok()??;
-    Some(Fixed(
-        mapping
-            .apply(skrifa::raw::types::Fixed::from_bits(coord.0))
-            .to_bits(),
-    ))
+    Some(Fixed(mapping.apply(Fixed::from_bits(coord.0)).to_bits()))
 }
 
 /// Returns a delta from an item variation store.

--- a/src/scale/hinting_cache.rs
+++ b/src/scale/hinting_cache.rs
@@ -11,7 +11,7 @@ use skrifa::{
 /// to redo it occasionally.
 const MAX_CACHED_HINT_INSTANCES: usize = 8;
 
-pub struct HintingKey<'a> {
+pub(crate) struct HintingKey<'a> {
     pub id: [u64; 2],
     pub outlines: &'a OutlineGlyphCollection<'a>,
     pub size: Size,

--- a/src/scale/mod.rs
+++ b/src/scale/mod.rs
@@ -544,7 +544,7 @@ impl<'a> Scaler<'a> {
         color_index: Option<u16>,
         outline: Option<&mut Outline>,
     ) -> bool {
-        let outline = match outline {
+        let mut outline = match outline {
             Some(x) => x,
             _ => &mut self.state.outline,
         };
@@ -561,7 +561,10 @@ impl<'a> Scaler<'a> {
                         )
                             .into()
                     };
-                if glyph.draw(settings, outline).is_ok() {
+                if glyph
+                    .draw(settings, &mut OutlineWriter(&mut outline))
+                    .is_ok()
+                {
                     outline.maybe_close();
                     outline.finish();
                     return true;

--- a/src/scale/outline.rs
+++ b/src/scale/outline.rs
@@ -400,24 +400,28 @@ fn compute_winding(points: &[Point]) -> u8 {
     }
 }
 
-impl skrifa::outline::OutlinePen for Outline {
+// The OutlineWriter wrapper allows us to make the trait implementation of OutlinePen
+// private which allows us to keep skrifa as a private dependency of swash
+pub(crate) struct OutlineWriter<'a>(pub &'a mut Outline);
+impl skrifa::outline::OutlinePen for OutlineWriter<'_> {
     fn move_to(&mut self, x: f32, y: f32) {
-        self.move_to((x, y).into());
+        self.0.move_to((x, y).into());
     }
 
     fn line_to(&mut self, x: f32, y: f32) {
-        self.line_to((x, y).into());
+        self.0.line_to((x, y).into());
     }
 
     fn quad_to(&mut self, cx0: f32, cy0: f32, x: f32, y: f32) {
-        self.quad_to((cx0, cy0).into(), (x, y).into());
+        self.0.quad_to((cx0, cy0).into(), (x, y).into());
     }
 
     fn curve_to(&mut self, cx0: f32, cy0: f32, cx1: f32, cy1: f32, x: f32, y: f32) {
-        self.curve_to((cx0, cy0).into(), (cx1, cy1).into(), (x, y).into());
+        self.0
+            .curve_to((cx0, cy0).into(), (cx1, cy1).into(), (x, y).into());
     }
 
     fn close(&mut self) {
-        self.close();
+        self.0.close();
     }
 }


### PR DESCRIPTION
We've been treating as private by doing technically breaking releases that change the `skrifa` version of this trait impl, so better to make the impl private.

I've also included a couple of minor code changes aimed at making easier to verify that `skrifa` is indeed a private dependency by reducing the scope in which types are available.