### PR TITLE
Add fn Script::is_real

### DIFF
--- a/src/text/unicode_data.rs
+++ b/src/text/unicode_data.rs
@@ -527,6 +527,14 @@ pub enum Script {
     Unknown = 156,
 }
 
+impl Script {
+    /// True if this is not an inherited/common/unknown script.
+    #[inline]
+    pub fn is_real(self) -> bool {
+        (self as u8) < 154
+    }
+}
+
 /// Canonical combining class.
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
 #[repr(u8)]


### PR DESCRIPTION
This method is defined by Parley but belongs here.

It's placed next to the enum to minimize the chance of changes to the enum rendering the impl invalid.