### PR TITLE
Upgrade skrifa to `0.36` and bump version to `0.2.6`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "swash"
-version = "0.2.5"
+version = "0.2.6"
 authors = ["Chad Brokaw <cbrokaw@gmail.com>"]
 edition = "2021"
 description = "Font introspection, complex text shaping and glyph rendering."
@@ -34,4 +34,4 @@ clippy.semicolon_if_nothing_returned = "warn"
 core_maths = { version = "0.1.1", optional = true }
 yazi = { version = "0.2.1", optional = true, default-features = false }
 zeno = { version = "0.3.3", optional = true, default-features = false }
-skrifa = { version = "0.35.0", default-features = false }
+skrifa = { version = "0.36.0", default-features = false }

--- a/src/shape/partition.rs
+++ b/src/shape/partition.rs
@@ -22,7 +22,7 @@ pub trait Selector {
 /// Trait for a font provided by a font selector.
 pub trait SelectedFont: PartialEq {
     /// Returns a reference to the underlying font.
-    fn font(&self) -> FontRef;
+    fn font(&self) -> FontRef<'_>;
 
     fn id_override(&self) -> Option<[u64; 2]> {
         None


### PR DESCRIPTION
Idea here is to bump Skrifa version and then release a new patch version.

Also added a drive-by clippy fix for a missing lifetime annotation.