### PR TITLE
Temporarily revert back to skrifa 0.35

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,4 +34,4 @@ clippy.semicolon_if_nothing_returned = "warn"
 core_maths = { version = "0.1.1", optional = true }
 yazi = { version = "0.2.1", optional = true, default-features = false }
 zeno = { version = "0.3.3", optional = true, default-features = false }
-skrifa = { version = "0.36.0", default-features = false }
+skrifa = { version = "0.35.0", default-features = false }


### PR DESCRIPTION
I want to put out a release with 0.35 to match vello `0.5.1` (Blitz is currently pulling in multiple versions of skrifa/read-fonts because parley/vello versions mismatch)