### PR TITLE
Upgrade skrifa to 0.40

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,4 +34,4 @@ clippy.semicolon_if_nothing_returned = "warn"
 core_maths = { version = "0.1.1", optional = true }
 yazi = { version = "0.2.1", optional = true, default-features = false }
 zeno = { version = "0.3.3", optional = true, default-features = false }
-skrifa = { version = ">= 0.31.1, <= 0.37", default-features = false }
+skrifa = { version = ">= 0.31.1, <= 0.40", default-features = false }


### PR DESCRIPTION
As far as I can tell (`cargo check --all-features`) this crate is compatible as is with skrifa up to 0.40.

A patch release would be appreciated to reduce the amount of dependencies for consumers :heart: 