### PR TITLE
fix `HintingCache` with default variations

### DIFF
--- a/src/scale/hinting_cache.rs
+++ b/src/scale/hinting_cache.rs
@@ -61,6 +61,8 @@ impl HintingCache {
 
 struct HintingEntry {
     id: [u64; 2],
+    size: Size,
+    coords: Vec<NormalizedCoord>,
     instance: HintingInstance,
     serial: u64,
 }
@@ -69,10 +71,7 @@ fn find_hinting_entry(entries: &mut Vec<HintingEntry>, key: &HintingKey) -> Opti
     let mut found_serial = u64::MAX;
     let mut found_index = 0;
     for (ix, entry) in entries.iter().enumerate() {
-        if entry.id == key.id
-            && entry.instance.size() == key.size
-            && entry.instance.location().coords() == key.coords
-        {
+        if entry.id == key.id && entry.size == key.size && entry.coords == key.coords {
             return Some((ix, true));
         }
         if entry.serial < found_serial {
@@ -85,6 +84,8 @@ fn find_hinting_entry(entries: &mut Vec<HintingEntry>, key: &HintingKey) -> Opti
         let ix = entries.len();
         entries.push(HintingEntry {
             id: key.id,
+            size: key.size,
+            coords: key.coords.to_vec(),
             instance,
             serial: 0,
         });


### PR DESCRIPTION
`skrifa` will ignore the variation coordinates if they are all default values (https://github.com/googlefonts/fontations/pull/1423). This broke the hinting cache because the coordinates from the skrifa `HintingInstance` were used to compare the cache key.

This PR stores copies of the `size` and `coords` in the cache entry instead of retrieving them from the `HintingInstance`.

Alternative: Could re-implement the `effective_coords` function (https://github.com/googlefonts/fontations/blob/d677a6bee28027a5d474bef20e0e6d156f7538a2/skrifa/src/instance.rs#L121-L127) and use those coords for the comparison, but any other changes to the `size` or `coords` of the `HintingInstance` would break the caching again, so I feel this is more robust.

Notably, `cosmic-text` will always include a default weight if the font supports it (since https://github.com/pop-os/cosmic-text/pull/400) and will currently rebuild the hinting for every rasterized glyph due to this bug. This adds ~100µs per glyph for Roboto on my machine.