### PR TITLE
Update skrifa to 0.42

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,4 +34,4 @@ clippy.semicolon_if_nothing_returned = "warn"
 core_maths = { version = "0.1.1", optional = true }
 yazi = { version = "0.2.1", optional = true, default-features = false }
 zeno = { version = "0.3.3", optional = true, default-features = false }
-skrifa = { version = ">= 0.31.1, <= 0.40", default-features = false }
+skrifa = { version = ">= 0.31.1, <= 0.42", default-features = false }

--- a/src/scale/hinting_cache.rs
+++ b/src/scale/hinting_cache.rs
@@ -31,10 +31,11 @@ const HINTING_MODE: HintingMode = HintingMode::Smooth {
 
 #[derive(Default)]
 pub(super) struct HintingCache {
-    // Split caches for glyf/cff because the instance type can reuse
-    // internal memory when reconfigured for the same format.
+    // Split caches because the instance type can reuse internal memory when
+    // reconfigured for the same format.
     glyf_entries: Vec<HintingEntry>,
     cff_entries: Vec<HintingEntry>,
+    other_entries: Vec<HintingEntry>,
     serial: u64,
 }
 
@@ -43,6 +44,8 @@ impl HintingCache {
         let entries = match key.outlines.format()? {
             OutlineGlyphFormat::Glyf => &mut self.glyf_entries,
             OutlineGlyphFormat::Cff | OutlineGlyphFormat::Cff2 => &mut self.cff_entries,
+            #[allow(unreachable_patterns)]
+            _ => &mut self.other_entries,
         };
         let (entry_ix, is_current) = find_hinting_entry(entries, key)?;
         let entry = entries.get_mut(entry_ix)?;


### PR DESCRIPTION
This PR upgrades `skrifa` dependency to 0.42. I'm using swash with harfrust. However harfrust depends on more recent version of `read-fonts`.

- swash 0.2.7 → skrifa 0.40 → read-fonts 0.37
- harfrust 0.7.0 → read-fonts 0.39

This caused a conflict in my app so I could not upgrade harfrust to the latest version and I needed to stick with harfrust 0.5.2. This PR aims to unlock the harfrust version upgrade.

All tests passed. I tried this branch with my app and I didn't find any issues.

The non-trivial change in this branch is that skrifa added `OutlineGlyphFormat::Varc` at 0.41.

https://docs.rs/skrifa/0.41.0/skrifa/outline/enum.OutlineGlyphFormat.html