### PR TITLE
Bump upper bound of `skrifa` version to 0.43

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,4 +34,4 @@ clippy.semicolon_if_nothing_returned = "warn"
 core_maths = { version = "0.1.1", optional = true }
 yazi = { version = "0.2.1", optional = true, default-features = false }
 zeno = { version = "0.3.3", optional = true, default-features = false }
-skrifa = { version = ">= 0.31.1, <= 0.42", default-features = false }
+skrifa = { version = ">= 0.31.1, <= 0.43", default-features = false }


### PR DESCRIPTION
The 0.43 upgrade didn't affect APIs used by swash so Cargo.toml is only modified. I confirmed:

- `cargo test --all-features` passed
- my app worked with swash 0.2.9 with this patch being applied

This change allows users to use read-fonts 0.40 as transitive dependency (current upper version of read-fonts is 0.39).