### PR TITLE
Fix computing winding in `embolden`

### DIFF
--- a/src/scale/outline.rs
+++ b/src/scale/outline.rs
@@ -197,7 +197,7 @@ impl<'a> LayerMut<'a> {
     pub fn embolden(&mut self, x_strength: f32, y_strength: f32) {
         let mut point_start = 0;
         let mut pos = 0;
-        let winding = compute_winding(self.points);
+        let winding = compute_winding(self.points, self.verbs);
         for verb in self.verbs {
             match verb {
                 Verb::MoveTo | Verb::Close => {
@@ -382,21 +382,56 @@ fn embolden(points: &mut [Point], winding: u8, x_strength: f32, y_strength: f32)
     }
 }
 
-fn compute_winding(points: &[Point]) -> u8 {
-    if points.is_empty() {
-        return 0;
-    }
+fn compute_winding(points: &[Point], verbs: &[Verb]) -> u8 {
     let mut area = 0.;
-    let last = points.len() - 1;
-    let mut prev = points[last];
-    for cur in points[0..=last].iter() {
-        area += (cur.y - prev.y) * (cur.x + prev.x);
-        prev = *cur;
+    let mut point_start = 0;
+    let mut pos = 0;
+
+    for verb in verbs {
+        match verb {
+            Verb::MoveTo | Verb::Close => {
+                if let Some(points) = points.get(point_start..pos) {
+                    area += compute_area(points);
+                    point_start = pos;
+                    if *verb == Verb::MoveTo {
+                        pos += 1;
+                    }
+                } else {
+                    return 0;
+                }
+            }
+            Verb::LineTo => pos += 1,
+            Verb::QuadTo => pos += 2,
+            Verb::CurveTo => pos += 3,
+        }
     }
+
+    if pos > point_start {
+        if let Some(points) = points.get(point_start..pos) {
+            area += compute_area(points);
+        } else {
+            return 0;
+        }
+    }
+
     if area > 0. {
         1
     } else {
         0
+    }
+}
+
+fn compute_area(points: &[Point]) -> f32 {
+    if let Some(last) = points.last() {
+        let mut prev = *last;
+        let mut area = 0.;
+        for cur in points {
+            area += (cur.y - prev.y) * (cur.x + prev.x);
+            prev = *cur;
+        }
+        area
+    } else {
+        0.
     }
 }
 


### PR DESCRIPTION
Fix #134 

`LayerMut::embolden` computed the winding from all points in a layer as one polygon. With disconnected contours, this adds nonexistent edges between contours to the area calculation and can reverse the winding. As a result, synthetic bold could shrink some glyphs, such as Monaco's `i` reported in #134.

This change computes the area for each contour separately and sums the results before determining the winding. Then the resulting global winding is used for all contours preserving the correct behavior for inner counter contours.

I verified this change with Monaco text on my app as follows. The existing tests and doc tests pass.

- Non-bold text

<img width="298" height="53" alt="Image" src="https://github.com/user-attachments/assets/bee7c9a1-0ff9-4d5e-9ebb-5ec808937c11" />

- Bold text before this fix

<img width="300" height="46" alt="Image" src="https://github.com/user-attachments/assets/3446c9ab-f97b-43f4-90c0-ade728316e20" />

- Bold text after this fix

<img width="299" height="54" alt="image" src="https://github.com/user-attachments/assets/98e73a7d-7122-4e21-86c3-cdcd017e48d4" />